### PR TITLE
Fix LPC845 test suite

### DIFF
--- a/lpc845-test-stand/test-assistant/src/main.rs
+++ b/lpc845-test-stand/test-assistant/src/main.rs
@@ -452,8 +452,6 @@ const APP: () = {
         loop {
             target_rx
                 .process_raw(|data| {
-                    rprintln!("Received message from target: {:?}", data);
-
                     host_tx.send_message(
                         &AssistantToHost::UsartReceive {
                             mode: UsartMode::Regular,
@@ -482,7 +480,6 @@ const APP: () = {
                             mode: UsartMode::Regular,
                             data,
                         } => {
-                            rprintln!("Sending regular USART message.");
                             target_tx.send_raw(data)
                         }
                         HostToAssistant::SendUsart {


### PR DESCRIPTION
This reverts commit 289e95bddc07d07c0640b09f06b2a78463a05df5.

Turns out that this broke all the USART tests of the LPC845 test suite.
Since the STM32L4 test suite is working now, this additional logging is
no longer necessary.