### PR TITLE
bugfix: make initial green pin level readable

### DIFF
--- a/lpc845-test-stand/test-suite/tests/gpio.rs
+++ b/lpc845-test-stand/test-suite/tests/gpio.rs
@@ -35,3 +35,10 @@ fn it_should_read_input_level() -> Result {
 
     Ok(())
 }
+
+#[test]
+fn it_should_read_input_level_without_level_change() -> Result {
+    let mut test_stand = TestStand::new()?;
+    assert!(test_stand.assistant.pin_is_high()?);
+    Ok(())
+}


### PR DESCRIPTION
@japaric noted that if you read a pin in a test before its level was changed the test will fail with

```
Error: Assistant(PinRead(UnexpectedMessage("ReadPinResult(None)")))
thread 'it_should_read_input_level_without_level_change' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /Users/lottesteenbrink/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:193:5
```

This is because the `pins` array that buffers that latest level status for each pin only gets an entry for said pin on the first interrupt (which is triggered by a level change).
This PR fixes this for the `green` pin, which si from my understanding the only pin that is directly user-queried.

I've also added a regression test for this; however this test needs to be executed first after flashing (since otherwise level changes will have happened, rendering the test useless). afaik tests will always be executed in random order so the test ist only half useful.